### PR TITLE
OMAP: Create exemple Structure file for OMAP4/5 PandaBoardES.

### DIFF
--- a/omap-tutorial/PandaBoard5.xml
+++ b/omap-tutorial/PandaBoard5.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ParameterFrameworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ParameterFrameworkConfiguration.xsd"
+    SystemClassName="Audio" ServerPort="5000" TuningAllowed="true">
+    <SubsystemPlugins>
+        <Location Folder="">
+            <Plugin Name="libalsa-subsystem.so"/>
+        </Location>
+    </SubsystemPlugins>
+    <StructureDescriptionFileLocation Path="Structure/Audio/Omap5Class.xml"/>
+    <SettingsConfiguration>
+        <ConfigurableDomainsFileLocation Path="Settings/Audio/AudioConfigurableDomains.xml"/>
+    </SettingsConfiguration>
+</ParameterFrameworkConfiguration>

--- a/omap-tutorial/PandaBoardES.xml
+++ b/omap-tutorial/PandaBoardES.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ParameterFrameworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ParameterFrameworkConfiguration.xsd"
+    SystemClassName="Audio" ServerPort="5000" TuningAllowed="true">
+    <SubsystemPlugins>
+        <Location Folder="">
+            <Plugin Name="libalsa-subsystem.so"/>
+        </Location>
+    </SubsystemPlugins>
+    <StructureDescriptionFileLocation Path="Structure/Audio/Omap4Class.xml"/>
+    <SettingsConfiguration>
+        <ConfigurableDomainsFileLocation Path="Settings/Audio/AudioConfigurableDomains.xml"/>
+    </SettingsConfiguration>
+</ParameterFrameworkConfiguration>

--- a/omap-tutorial/README.md
+++ b/omap-tutorial/README.md
@@ -1,0 +1,204 @@
+# OMAP tutorial
+
+This directory contains OMAP exemple for PandaBoardES and Pand5-uevm board.
+
+## OMAP Environment setup:
+
+This part is describing OMAP environement setup for PANDA board.
+
+### Bootloader and Kernel
+This section is describing how to build the different bootloader and kernel components.
+
+- u-boot:
+--------
+For u-boot the upstream mainline is supporting OMAP devices. A simple patch is needed in order to ensure the configuration of the OMAP ABE DPLL to use the SYSCLK for the ABE DPLL.
+
+```
+git clone git://git.denx.de/u-boot.git
+```
+
+Add the #define CONFIG_SYS_OMAP_ABE_SYSCK inside ./include/configs/omap4_panda.h
+```
+make CROSS_COMPILE=arm-none-linux-gnueabi- omap4_panda_config
+make CROSS_COMPILE=arm-none-linux-gnueabi- ARCH=arm
+```
+=> Generation `MLO` and `u-boot.img` for boot partition
+
+- kernel:
+--------
+As OMAP ABE code is not upstream the next tree is sharing a Kernel image based on 3.14 kernel. This image is enabling ABE and still need some improvement for stability.
+
+```
+git clone git://gitorious.org/omap-audio/linux-audio.git
+git checkout origin/sgc/topic/pfw_omap
+make CROSS_COMPILE=arm-none-linux-gnueabi- ARCH=arm omap2plus_defconfig
+make CROSS_COMPILE=arm-none-linux-gnueabi- ARCH=arm uImage -j5
+make CROSS_COMPILE=arm-none-linux-gnueabi- ARCH=arm dtbs
+cd arch/arm/boot
+mkimage -A arm -O linux -T kernel -C none -a 0x80008000 -e 0x80008000 -n "Linux" -d zImage uImage
+```
+=> Copy uImage and `omap4-panda-es.dtb` on the boot partition
+
+
+### OMAP Audio BackEnd Firmware generation
+This section is describing how to generated the OMAP4+  ABE FW and the ASoC-DFW header for Audio Firmware binaries.
+
+#### OMAP AESS/ABE FW:
+
+* OMAP ABE tool:
+
+This tool is used in order to add some FW binary data on top of the firmware. The kernel driver is usem them in order to get all the different FW address for the audio cluster and port configuration.
+
+```
+git clone git://gitorious.org/omap-audio/abefw.git
+./autogen.sh
+./configure --with-linux-dir=/path/to/linux.git
+make
+sudo make install
+./scripts/abe_tool.h 009590
+```
+
+#### ASoC-DFW tool:
+* ASoC-DFW tool
+
+This tool is used to create all the binary data for the mixer controls, DAPM graph for the Audio driver.
+
+```
+git clone git://gitorious.org/omap-audio/asoc-fw.git
+git checkout origin/sgc/topic/pfw_omap
+./autogen.sh
+./configure --with-linux-dir=/path/to/linux.git --enable-omap4
+make
+sudo make install
+./scripts/abegen.sh
+```
+=> generate `omap4_abe_new` FW file. To be copy inside `/lib/firmware/omap_aess-adfw.bin`
+
+### File System generation
+
+The PFW test has been done with UBUNTU Core File System or Poky minimal image..
+
+#### UBUNTU File System:
+Download ubuntu core FS.
+=> Untar the FS on the File system partition
+
+* Remove Root password
+```
+sudo gedit /media/rootfs/etc/shadow
+```
+Remove the star `*` after `root:` inside the file
+```
+ root::...
+```
+
+* Update the console port
+
+Create new file: /etc/init/serial.conf
+```
+sudo nano /media/rootfs/etc/init/serial.conf
+```
+Content
+```
+start on stopped rc RUNLEVEL=[2345]
+stop on runlevel [!2345]
+
+respawn
+exec /sbin/getty 115200 ttyO2
+```
+
+## PFW setup for native compilation:
+
+### UBUNTU package install for compilation on board.
+
+Boot the board and install the different package needed.
+```
+sudo apt-get install build-essential cmake vim
+sudo apt-get install libasound2-dev libxml2-dev
+```
+
+### Repository to Clone:
+Create a folder intel
+Clone the different git tree for PFW.
+```
+git clone http://github.com/01org/parameter-framework.git
+git clone http://github.com/01org/parameter-framework-plugins-alsa.git
+git clone http://github.com/01org/parameter-framework-samples.git
+```
+
+### Parameter Framework:
+Follow the README in order to compile PFW and the plugin.
+
+Compile the different modules on the File system with native compilation.
+
+
+## Test on Board
+Go to parameter-framework-samples folder.
+Go to omap-tutorial folder.
+```
+ # Use the path set during Cmake build of PFW core.
+export LD_LIBRARY_PATH=/usr/local/lib
+
+test-platform ./PandaBoardES.xml
+remote-process localhost 5001 start
+remote-process localhost 5000 listParameters /Audio
+remote-process localhost 5000 help
+```
+Exemple for Headset Playback on Media port.
+```
+ # Enable Tuning mode (just need once)
+remote-process localhost 5000 setTuningMode on
+ # Configure Codec
+remote-process localhost 5000 setParameter /Audio/omapabe/twl6040/output/headset/volume 12
+remote-process localhost 5000 setParameter /Audio/omapabe/twl6040/output/headset/enable/right hs_dac
+remote-process localhost 5000 setParameter /Audio/omapabe/twl6040/output/headset/enable/left hs_dac
+ # Configure ABE/AESS
+remote-process localhost 5000 setParameter /Audio/omapabe/abe/output/headset/dl1/media_playback 120
+remote-process localhost 5000 setParameter /Audio/omapabe/abe/output/headset/dl1/mixer_media 1
+remote-process localhost 5000 setParameter /Audio/omapabe/abe/output/headset/sdt_dl 1
+remote-process localhost 5000 setParameter /Audio/omapabe/abe/output/headset/sdt_dl_volume/volume 120
+remote-process localhost 5000 setParameter /Audio/omapabe/abe/output/pdm 1
+ # Test playback
+aplay -Dplughw:0,0 test.wav
+```
+
+# TODO:
+
+Create some PFW file for the setting of the different Path.
+For Pandaboard:
+ - Modem/VoiceCall is not supported
+ - Earpiece and IHF are not supported
+ - DMICs are not supported
+
+Capture ports:
+ - Media => MM_UL2
+ - MultiChannel => MM_UL2
+ - Voice => VX_UL
+ - Modem => VX_UL (dummy FE)
+Playback ports:
+ - Media => MM_DL
+ - Tones => TONES_DL
+ - Voice => VX_DL
+ - Modem => VX_DL (dummy FE)
+ - DeepMedia => PingPong port Low Power.
+
+
+List of criterions for OMAP ABE:
+-------------------------------
+```
+ExclusiveCriterion  Mode                   :  InCsvCall         InVoipCall       Normal
+InclusiveCriterion  RoutageState           :  Configure         Flow             Path
+InclusiveCriterion  ClosingCaptureRoutes   :  Media     Modem     Voice     MultiChannel
+InclusiveCriterion  ClosingPlaybackRoutes  :  Media     Modem     Voice     Tones        DeepMedia
+InclusiveCriterion  OpenedCaptureRoutes    :  Media     Modem     Voice     MultiChannel
+InclusiveCriterion  OpenedPlaybackRoutes   :  Media     Modem     Voice     Tones        DeepMedia
+InclusiveCriterion  SelectedInputDevice    :  SubMic             Headset    MainMic    Dmic1    Dmic2     Dmic1
+InclusiveCriterion  SelectedOutputDevice   :  Earpiece   Headset        Ihf
+InclusiveCriterion  AudioSource            :  Default          Mic              None              VoiceCall  VoiceCommunication  VoiceDownlink  VoiceUplink
+ExclusiveCriterion  BandType               :  NB                SuperWB          Unknown          WB
+ExclusiveCriterion  ScreenState            :  Off               On
+```
+
+Link:
+====
+http://www.omappedia.com/wiki/Audio_Drive_Arch
+

--- a/omap-tutorial/Settings/Audio/AudioConfigurableDomains.xml
+++ b/omap-tutorial/Settings/Audio/AudioConfigurableDomains.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Audio">
+    <ConfigurableDomain Name="Omap">
+        <Configurations>
+            <Configuration Name="Omap"></Configuration>
+        </Configurations>
+        <ConfigurableElements></ConfigurableElements>
+    </ConfigurableDomain>
+</ConfigurableDomains>

--- a/omap-tutorial/Structure/Audio/Omap4Class.xml
+++ b/omap-tutorial/Structure/Audio/Omap4Class.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/SystemClass.xsd" Name="Audio">
+  <SubsystemInclude Path="PandaBoardESSubSystem.xml"/>
+</SystemClass>

--- a/omap-tutorial/Structure/Audio/Omap5Class.xml
+++ b/omap-tutorial/Structure/Audio/Omap5Class.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/SystemClass.xsd" Name="Audio">
+  <SubsystemInclude Path="PandaBoard5SubSystem.xml"/>
+</SystemClass>

--- a/omap-tutorial/Structure/Audio/OmapAbeComponentTypeSet.xml
+++ b/omap-tutorial/Structure/Audio/OmapAbeComponentTypeSet.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ComponentTypeSet xmlns:xi="http://www.w3.org/2001/XInclude"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../Schemas/ComponentTypeSet.xsd">
+
+    <!-- === Generic === -->
+    <ComponentType Name="Volume">
+        <IntegerParameter Name="volume" Min="0" Max="150" Size="8" Mapping="Control:%1 %2 Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+    </ComponentType>
+    <ComponentType Name="Volume2">
+        <IntegerParameter Name="volume" ArrayLength="2" Min="0" Max="150" Size="8" Mapping="Control:%1 %2 Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+    </ComponentType>
+    <!-- === Outputs === -->
+
+    <!-- Outputs / Generic -->
+    <ComponentType Name="OutputMixer">
+        <IntegerParameter Name="media_playback" Min="0" Max="150" Size="8" Mapping="Control:%1 Media Playback Volume" Description="Limits: -12..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="tones_playback" Min="0" Max="150" Size="8" Mapping="Control:%1 Tones Playback Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="voice_playback" Min="0" Max="150" Size="8" Mapping="Control:%1 Voice Playback Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="capture_playback" Min="0" Max="150" Size="8" Mapping="Control:%1 Capture Playback Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <BooleanParameter Name="mixer_media"  Mapping="Control:%1 Mixer Multimedia"/>
+        <BooleanParameter Name="mixer_tones"  Mapping="Control:%1 Mixer Tones"/>
+        <BooleanParameter Name="mixer_voice"  Mapping="Control:%1 Mixer Voice"/>
+        <BooleanParameter Name="mixer_capture"  Mapping="Control:%1 Mixer Capture"/>
+        <BooleanParameter Name="mixer_mono"  Mapping="Control:%1 Mono Mixer"/>
+    </ComponentType>
+
+    <!-- Outputs / Headset/Earpiece -->
+    <ComponentType Name="AbeDl1Output">
+        <Component Name="dl1" Type="OutputMixer" Mapping="Amend1:DL1"/>
+        <BooleanParameter Name="sdt_dl"  Mapping="Control:Sidetone Mixer Playback"/>
+        <BooleanParameter Name="sdt_ul"  Mapping="Control:Sidetone Mixer Capture"/>
+        <Component Name="sdt_dl_volume" Type="Volume" Mapping="Amend1:SDT,Amend2:DL"/>
+        <Component Name="sdt_ul_volume" Type="Volume" Mapping="Amend1:SDT,Amend2:UL"/>
+        <BooleanParameter Name="bt" Mapping="Control:DL1 BT_VX Switch"/>
+        <BooleanParameter Name="mm_ext" Mapping="Control:DL1 MM_EXT Switch"/>
+    </ComponentType>
+
+    <!-- Outputs / Root Component -->
+    <ComponentType Name="AbeOutputs">
+        <Component Name="handsfree" Type="OutputMixer" Mapping="Amend1:DL2"/>
+        <Component Name="headset" Type="AbeDl1Output"/>
+        <BooleanParameter Name="pdm"  Mapping="Control:DL1 PDM Switch"/>
+    </ComponentType>
+
+    <!-- === Inputs === -->
+    <ComponentType Name="Source">
+        <EnumParameter Name="route" Size="8" Mapping="Control:%1">
+            <ValuePair Literal="none" Numerical="0"/>
+            <ValuePair Literal="dmic1_left" Numerical="1"/>
+            <ValuePair Literal="dmic1_right" Numerical="2"/>
+            <ValuePair Literal="dmic2_left" Numerical="3"/>
+            <ValuePair Literal="dmic2_right" Numerical="4"/>
+            <ValuePair Literal="dmic3_left" Numerical="5"/>
+            <ValuePair Literal="dmic3_right" Numerical="6"/>
+            <ValuePair Literal="bt_left" Numerical="7"/>
+            <ValuePair Literal="bt_right" Numerical="8"/>
+            <ValuePair Literal="mm_ext_left" Numerical="9"/>
+            <ValuePair Literal="mm_ext_right" Numerical="10"/>
+            <ValuePair Literal="amic_left" Numerical="11"/>
+            <ValuePair Literal="amic_right" Numerical="12"/>
+            <ValuePair Literal="vxrec_left" Numerical="13"/>
+            <ValuePair Literal="vxrec_right" Numerical="14"/>
+        </EnumParameter>
+    </ComponentType>
+
+    <ComponentType Name="InputMixer">
+        <IntegerParameter Name="media_playback" Min="0" Max="150" Size="8" Mapping="Control:%2 Media Volume" Description="Limits: -12..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="tones_playback" Min="0" Max="150" Size="8" Mapping="Control:%2 Tones Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="voice_dl" Min="0" Max="150" Size="8" Mapping="Control:%2 Voice DL Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <IntegerParameter Name="capture_ul" Min="0" Max="150" Size="8" Mapping="Control:%2 Voice UL Volume" Description="Limits: -120..30, dBscale-min=-120dB, dBscale-max=30dB, step=1dB"/>
+        <BooleanParameter Name="mixer_media"  Mapping="Control:%1 Mixer Media Playback"/>
+        <BooleanParameter Name="mixer_tones"  Mapping="Control:%1 Mixer Tones"/>
+        <BooleanParameter Name="mixer_voice_ul"  Mapping="Control:%1 Mixer Voice Capture"/>
+        <BooleanParameter Name="mixer_voice_dl"  Mapping="Control:%1 Mixer Voice Playback"/>
+        <BooleanParameter Name="mixer_mono"  Mapping="Control:%2 Mono Mixer"/>
+    </ComponentType>
+
+    <!-- Inputs / Root Component -->
+    <ComponentType Name="AbeInputs">
+        <Component Name="amic" Type="Volume2" Mapping="Amend1:AMIC,Amend2:UL"/>
+        <Component Name="dmic1" Type="Volume2" Mapping="Amend1:DMIC1,Amend2:UL"/>
+        <Component Name="dmic2" Type="Volume2" Mapping="Amend1:DMIC2,Amend2:UL"/>
+        <Component Name="dmic3" Type="Volume2" Mapping="Amend1:DMIC3,Amend2:UL"/>
+        <Component Name="bt_ul" Type="Volume2" Mapping="Amend1:BT,Amend2:UL"/>
+        <Component Name="ul_ch0" Type="Source" Mapping="Amend1:MUX_UL10"/>
+        <Component Name="ul_ch1" Type="Source" Mapping="Amend1:MUX_UL11"/>
+        <Component Name="ul_ch2" Type="Source" Mapping="Amend1:MUX_UL00"/>
+        <Component Name="ul_ch3" Type="Source" Mapping="Amend1:MUX_UL01"/>
+        <Component Name="ul_ch4" Type="Source" Mapping="Amend1:MUX_UL02"/>
+        <Component Name="ul_ch5" Type="Source" Mapping="Amend1:MUX_UL03"/>
+        <Component Name="ul2_left" Type="Source" Mapping="Amend1:MUX_UL04"/>
+        <Component Name="ul2_right" Type="Source" Mapping="Amend1:MUX_UL05"/>
+        <Component Name="vx_ch0" Type="Source" Mapping="Amend1:MUX_VX0"/>
+        <Component Name="vx_ch1" Type="Source" Mapping="Amend1:MUX_VX1"/>
+        <Component Name="voice" Type="InputMixer" Mapping="Amend1:Capture,Amend2:AUDUL"/>
+    </ComponentType>
+
+    <ComponentType Name="OmapAbe">
+        <Component Name="output" Type="AbeOutputs"/>
+        <Component Name="input" Type="AbeInputs"/>
+    </ComponentType>
+
+</ComponentTypeSet>

--- a/omap-tutorial/Structure/Audio/PandaBoard5SubSystem.xml
+++ b/omap-tutorial/Structure/Audio/PandaBoard5SubSystem.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="omapabe" Type="ALSA" Endianness="Little" Mapping="Card:omap5uevm">
+    <ComponentLibrary>
+        <xi:include href="Twl6040ComponentTypeSet.xml"/>
+        <xi:include href="OmapAbeComponentTypeSet.xml"/>
+    </ComponentLibrary>
+    <InstanceDefinition>
+        <Component Name="twl6040" Type="Twl6040"/>
+        <Component Name="abe" Type="OmapAbe"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/omap-tutorial/Structure/Audio/PandaBoardESSubSystem.xml
+++ b/omap-tutorial/Structure/Audio/PandaBoardESSubSystem.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="omapabe" Type="ALSA" Endianness="Little" Mapping="Card:PandaBoardES">
+    <ComponentLibrary>
+        <xi:include href="Twl6040ComponentTypeSet.xml"/>
+        <xi:include href="OmapAbeComponentTypeSet.xml"/>
+    </ComponentLibrary>
+    <InstanceDefinition>
+        <Component Name="twl6040" Type="Twl6040"/>
+        <Component Name="abe" Type="OmapAbe"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/omap-tutorial/Structure/Audio/Twl6040ComponentTypeSet.xml
+++ b/omap-tutorial/Structure/Audio/Twl6040ComponentTypeSet.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ComponentTypeSet xmlns:xi="http://www.w3.org/2001/XInclude"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../Schemas/ComponentTypeSet.xsd">
+
+    <!-- === Generic === -->
+    <ComponentType Name="PowerMode">
+        <EnumParameter Name="value" Size="8" Mapping="Control:%1 Power Mode">
+            <ValuePair Literal="low-power" Numerical="0"/>
+            <ValuePair Literal="high-performance" Numerical="1"/>
+        </EnumParameter>
+    </ComponentType>
+
+    <!-- === Outputs === -->
+
+    <!-- Outputs / Handsfree -->
+    <ComponentType Name="HandsfreeEnable">
+        <BooleanParameter Name="right"  Mapping="Control:%1 Right Playback"/>
+        <BooleanParameter Name="left"  Mapping="Control:%1 Left Playback"/>
+    </ComponentType>
+    <ComponentType Name="HandsfreeOutput">
+        <IntegerParameter Name="volume" ArrayLength="2" Size="8" Min="0" Max="30" Mapping="Control:%1 Playback Volume"/>
+        <Component Name="enable" Type="HandsfreeEnable"/>
+    </ComponentType>
+
+    <!-- Outputs / Headset -->
+    <ComponentType Name="HeadsetEnable">
+        <EnumParameter Name="right" Size="8" Mapping="Control:%1 Right Playback">
+            <ValuePair Literal="off" Numerical="0"/>
+            <ValuePair Literal="hs_dac" Numerical="1"/>
+            <ValuePair Literal="line-in_amp" Numerical="2"/>
+        </EnumParameter>
+        <EnumParameter Name="left" Size="8" Mapping="Control:%1 Left Playback">
+            <ValuePair Literal="off" Numerical="0"/>
+            <ValuePair Literal="hs_dac" Numerical="1"/>
+            <ValuePair Literal="line-in_amp" Numerical="2"/>
+        </EnumParameter>
+    </ComponentType>
+    <ComponentType Name="HeadsetOutput">
+        <IntegerParameter Name="volume" ArrayLength="2" Size="8" Min="0" Max="15" Mapping="Control:%1 Playback Volume"/>
+        <Component Name="enable" Type="HeadsetEnable"/>
+    </ComponentType>
+
+    <!-- Outputs / Earpiece -->
+    <ComponentType Name="EarpieceOutput">
+        <IntegerParameter Name="volume" Size="8" Min="0" Max="15" Mapping="Control:%2 Playback Volume"/>
+        <BooleanParameter Name="enable"  Mapping="Control:%2 Playback Switch"/>
+    </ComponentType>
+
+    <!-- Outputs / Aux -->
+    <ComponentType Name="AuxOutput">
+        <BooleanParameter Name="right"  Mapping="Control:%1 Playback Switch"/>
+        <BooleanParameter Name="left"  Mapping="Control:%2 Playback Switch"/>
+    </ComponentType>
+
+    <!-- Outputs / Vibra -->
+    <ComponentType Name="VibraOutput">
+        <EnumParameter Name="right" Size="8" Mapping="Control:%1 Right Playback">
+            <ValuePair Literal="input_ff" Numerical="0"/>
+            <ValuePair Literal="audio_pdm" Numerical="1"/>
+        </EnumParameter>
+        <EnumParameter Name="left" Size="8" Mapping="Control:%1 Left Playback">
+            <ValuePair Literal="input_ff" Numerical="0"/>
+            <ValuePair Literal="audio_pdm" Numerical="1"/>
+        </EnumParameter>
+    </ComponentType>
+
+    <!-- Outputs / Root Component -->
+    <ComponentType Name="Outputs">
+        <Component Name="handsfree" Type="HandsfreeOutput" Mapping="Amend1:Handsfree,Amend2:HF"/>
+        <Component Name="headset" Type="HeadsetOutput" Mapping="Amend1:Headset,Amend2:HS"/>
+        <Component Name="earpiece" Type="EarpieceOutput" Mapping="Amend1:Earpiece,Amend2:Earphone"/>
+        <Component Name="vibra" Type="VibraOutput" Mapping="Amend1:Vibra"/>
+        <Component Name="aux" Type="AuxOutput" Mapping="Amend1:AUXR,Amend2:AUXL"/>
+        <Component Name="hs_power_mode" Type="PowerMode" Mapping="Amend1:Headset"/>
+    </ComponentType>
+
+    <!-- === Inputs === -->
+
+    <!-- Inputs -->
+    <ComponentType Name="AnalogRoute">
+        <EnumParameter Name="mux" Size="8" Mapping="Control:Analog %1 Capture Route">
+            <ValuePair Literal="headset_mic" Numerical="0"/>
+            <ValuePair Literal="main_mic" Numerical="1"/>
+            <ValuePair Literal="aux_fm" Numerical="2"/>
+            <ValuePair Literal="off" Numerical="3"/>
+        </EnumParameter>
+    </ComponentType>
+
+    <!-- Inputs / Root Component -->
+    <ComponentType Name="Inputs">
+        <Component Name="right" Type="AnalogRoute" Mapping="Amend1:Right"/>
+        <Component Name="left" Type="AnalogRoute" Mapping="Amend1:Left"/>
+        <IntegerParameter Name="volume" ArrayLength="2" Size="8" Min="0" Max="4" Mapping="Control:Capture Volume" Description="Limits: 6..30, dBscale-min=6dB, dBscale-max=30dB, step=6dB"/>
+        <IntegerParameter Name="pre_volume" ArrayLength="2" Size="8" Min="0" Max="1" Mapping="Control:Capture Preamplifier Volume" Description="Limits: -6..0, dBscale-min=-6dB, dBscale-max=0dB, step=6dB"/>
+        <IntegerParameter Name="aux_volume" ArrayLength="2" Size="8" Min="0" Max="7" Mapping="Control:Aux FM Volume" Description="Limits: -18..24, dBscale-min=-186dB, dBscale-max=24dB, step=6dB"/>
+    </ComponentType>
+
+    <ComponentType Name="Twl6040">
+        <Component Name="output" Type="Outputs"/>
+        <Component Name="input" Type="Inputs"/>
+        <Component Name="power_mode" Type="PowerMode" Mapping="Amend1:TWL6040"/>
+    </ComponentType>
+
+</ComponentTypeSet>


### PR DESCRIPTION
This patch is adding reference structure file for OMAP4/5 Panda.
It is including the reference Structure file. Some additional
work is needed to create the different PFW XML file for routing.
Files has been tested on both PandaBoardES and PandaBoard5 (uevm)

TODO: Create scritp for ALSA playback/capture with PFW criteria.

Signed-off-by: Sebastien Guirec <sebastien.guiriec@intel.com>