### PR TITLE
Core Tutorial/CMake: fix how files are configured and installed

### DIFF
--- a/core-tutorial/CMakeLists.txt
+++ b/core-tutorial/CMakeLists.txt
@@ -1,11 +1,8 @@
-set(PLUGIN_LOCATION_FOLDER "${CMAKE_PREFIX_PATH}/lib")
-set(INSTALL_LOCATION_FOLDER ${CMAKE_INSTALL_PREFIX})
+configure_file(Structure/MyMusic.xml.in ${CMAKE_CURRENT_BINARY_DIR}/Structure/MyMusic.xml @ONLY)
 
-message("plugin location = ${PLUGIN_LOCATION_FOLDER}")
-message("install location = ${INSTALL_LOCATION_FOLDER}")
-
-configure_file(ParameterFrameworkConfiguration.xml ${CMAKE_INSTALL_PREFIX}/ParameterFrameworkConfiguration.xml)
-configure_file(Structure/MyMusic.xml ${CMAKE_INSTALL_PREFIX}/Structure/MyMusic.xml)
+install(FILES
+    ParameterFrameworkConfiguration.xml
+    DESTINATION .)
 
 install(FILES
     Settings/Genres.xml
@@ -13,6 +10,7 @@ install(FILES
 
 install(FILES
     Structure/MusicLibraries.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/Structure/MyMusic.xml
     DESTINATION Structure)
 
 install(FILES

--- a/core-tutorial/ParameterFrameworkConfiguration.xml
+++ b/core-tutorial/ParameterFrameworkConfiguration.xml
@@ -2,7 +2,7 @@
 <ParameterFrameworkConfiguration
     SystemClassName="MusicLibrary" ServerPort="5000" TuningAllowed="true">
     <SubsystemPlugins>
-        <Location Folder="@PLUGIN_LOCATION_FOLDER@">
+        <Location Folder="">
             <Plugin Name="libfs-subsystem.so"/>
         </Location>
     </SubsystemPlugins>

--- a/core-tutorial/Structure/MyMusic.xml.in
+++ b/core-tutorial/Structure/MyMusic.xml.in
@@ -12,6 +12,6 @@
     </ComponentLibrary>
 
     <InstanceDefinition>
-        <Component Name="artists" Type="Artists" Mapping="Directory:@INSTALL_LOCATION_FOLDER@/libraries"/>
+        <Component Name="artists" Type="Artists" Mapping="Directory:@CMAKE_INSTALL_PREFIX@/libraries"/>
     </InstanceDefinition>
 </Subsystem>


### PR DESCRIPTION
configure_file was used to install a file during the invocation of "cmake",
which is wrong. Instead, it must be used to locally transform a file from
source to build dir.

Also, since the Parameter Framework's v2.3.0 release, the "Folder" attribute of
the PluginLocation tag can be empty. It is therefore useless to configure it.